### PR TITLE
Made project a shadeable project instead of being a required plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,13 @@
 # UserInterfaces
 Allows you to support Bedrock and Java players with your user interfaces simultaneously.
+
+## Setting up UserInterfaces
+To enable UserInterfaces within your plugin run the following:
+```java
+UserInterfaces#enable(JavaPlugin);
+```
+
+## Features 
+- ChestInterface
+- TextInterface
+- BookInterface

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>me.xemor</groupId>
     <artifactId>UserInterface</artifactId>
-    <version>1.6.6-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>UserInterface</name>

--- a/src/main/java/me/xemor/userinterface/BookInterface.java
+++ b/src/main/java/me/xemor/userinterface/BookInterface.java
@@ -18,6 +18,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.UUID;
 
+@SuppressWarnings("unused")
 public class BookInterface {
 
     private String formTitle = "";

--- a/src/main/java/me/xemor/userinterface/BookInterface.java
+++ b/src/main/java/me/xemor/userinterface/BookInterface.java
@@ -70,7 +70,7 @@ public class BookInterface {
     private Book createJavaBook(Player player) {
         TextComponent.Builder page = Component.text()
             .append(Component.text(content + "\n"));
-        for (Button button : buttons) page.append(Component.text(button.name.replaceAll("%bullet%", bullet) + "\n").clickEvent(ClickEvent.runCommand("/ufbook " + player.getUniqueId() + " " + button.identifier)).hoverEvent(Component.text(button.hoverText)));
+        for (Button button : buttons) page.append(Component.text(button.name.replaceAll("%bullet%", bullet) + "\n").clickEvent(ClickEvent.runCommand("/ufbook " + UserInterface.getPlugin().getName().toLowerCase() + " "  + player.getUniqueId() + " " + button.identifier)).hoverEvent(Component.text(button.hoverText)));
         Collection<Component> pages = new ArrayList<>();
         pages.add(page.build());
         return Book.book(Component.text("UFBook"), Component.text("Dav_e_"), pages);

--- a/src/main/java/me/xemor/userinterface/ChestHandler.java
+++ b/src/main/java/me/xemor/userinterface/ChestHandler.java
@@ -3,7 +3,6 @@ package me.xemor.userinterface;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
-import org.bukkit.event.inventory.InventoryAction;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryCloseEvent;
 import org.bukkit.inventory.Inventory;

--- a/src/main/java/me/xemor/userinterface/ChestInterface.java
+++ b/src/main/java/me/xemor/userinterface/ChestInterface.java
@@ -16,6 +16,7 @@ import java.util.Map;
  * /       _
  * """
  */
+@SuppressWarnings("unused")
 public class ChestInterface<T> {
 
     private final Inventory inventory;

--- a/src/main/java/me/xemor/userinterface/InventoryInteractions.java
+++ b/src/main/java/me/xemor/userinterface/InventoryInteractions.java
@@ -12,6 +12,7 @@ import java.util.*;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 
+@SuppressWarnings("unused")
 public class InventoryInteractions<T> implements InventoryHolder {
 
     @Nullable

--- a/src/main/java/me/xemor/userinterface/SignMenuFactory/SignMenuFactory.java
+++ b/src/main/java/me/xemor/userinterface/SignMenuFactory/SignMenuFactory.java
@@ -21,6 +21,7 @@ import java.util.Objects;
 import java.util.function.BiPredicate;
 import java.util.stream.Collectors;
 
+@SuppressWarnings("unused")
 public final class SignMenuFactory {
 
     private final Plugin plugin;

--- a/src/main/java/me/xemor/userinterface/TextInterface.java
+++ b/src/main/java/me/xemor/userinterface/TextInterface.java
@@ -14,7 +14,7 @@ public class TextInterface {
     private String placeholder = "";
 
     private String inputName = "Input";
-    private final SignMenuFactory factory = new SignMenuFactory(UserInterface.getInstance());
+    private final SignMenuFactory factory = new SignMenuFactory(UserInterface.getPlugin());
 
     public TextInterface title(String title) {
         this.title = title;

--- a/src/main/java/me/xemor/userinterface/TextInterface.java
+++ b/src/main/java/me/xemor/userinterface/TextInterface.java
@@ -8,6 +8,7 @@ import org.geysermc.floodgate.api.FloodgateApi;
 import java.util.Arrays;
 import java.util.function.Consumer;
 
+@SuppressWarnings("unused")
 public class TextInterface {
 
     private String title = "";

--- a/src/main/java/me/xemor/userinterface/UserInterface.java
+++ b/src/main/java/me/xemor/userinterface/UserInterface.java
@@ -4,33 +4,37 @@ import me.xemor.userinterface.commands.BookInterfaceCmd;
 import net.kyori.adventure.platform.bukkit.BukkitAudiences;
 import org.bukkit.plugin.java.JavaPlugin;
 
-public final class UserInterface extends JavaPlugin {
-
-    private static UserInterface userInterface;
-    private static boolean hasFloodgate;
+public final class UserInterface {
+    private static JavaPlugin plugin;
     private static BukkitAudiences bukkitAudiences;
+    private static boolean hasFloodgate;
 
-    @Override
-    public void onEnable() {
-        // Plugin startup logic
-        userInterface = this;
-        bukkitAudiences = BukkitAudiences.create(this);
+    public static void enable(JavaPlugin plugin) {
+        UserInterface.plugin = plugin;
+
+        bukkitAudiences = BukkitAudiences.create(plugin);
         ChestHandler chestHandler = new ChestHandler();
 
-        if (this.getServer().getPluginManager().getPlugin("Floodgate") != null) hasFloodgate= true;
-        else {
+        if (plugin.getServer().getPluginManager().getPlugin("Floodgate") != null) {
+            hasFloodgate = true;
+            plugin.getLogger().info("Floodgate plugin found. Enabling Floodgate support.");
+        } else {
             hasFloodgate = false;
-            getLogger().info("Floodgate plugin not found. Continuing without Floodgate.");
         }
-        this.getCommand("ufbook").setExecutor(new BookInterfaceCmd());
-        this.getServer().getPluginManager().registerEvents(chestHandler, this);
+
+        plugin.getCommand("ufbook").setExecutor(new BookInterfaceCmd());
+        plugin.getServer().getPluginManager().registerEvents(chestHandler, plugin);
     }
 
-    public static UserInterface getInstance() {
-        return userInterface;
+    public static JavaPlugin getPlugin() {
+        return plugin;
     }
 
-    public static boolean hasFloodgate() { return hasFloodgate; }
+    public static BukkitAudiences getBukkitAudiences() {
+        return bukkitAudiences;
+    }
 
-    public static BukkitAudiences getBukkitAudiences() { return bukkitAudiences; }
+    public static boolean hasFloodgate() {
+        return hasFloodgate;
+    }
 }

--- a/src/main/java/me/xemor/userinterface/UserInterface.java
+++ b/src/main/java/me/xemor/userinterface/UserInterface.java
@@ -16,12 +16,7 @@ public final class UserInterface {
         bukkitAudiences = BukkitAudiences.create(plugin);
         ChestHandler chestHandler = new ChestHandler();
 
-        if (plugin.getServer().getPluginManager().getPlugin("Floodgate") != null) {
-            hasFloodgate = true;
-            plugin.getLogger().info("Floodgate plugin found. Enabling Floodgate support.");
-        } else {
-            hasFloodgate = false;
-        }
+        hasFloodgate = plugin.getServer().getPluginManager().getPlugin("Floodgate") != null;
 
         plugin.getCommand("ufbook").setExecutor(new BookInterfaceCmd());
         plugin.getServer().getPluginManager().registerEvents(chestHandler, plugin);

--- a/src/main/java/me/xemor/userinterface/UserInterface.java
+++ b/src/main/java/me/xemor/userinterface/UserInterface.java
@@ -4,6 +4,7 @@ import me.xemor.userinterface.commands.BookInterfaceCmd;
 import net.kyori.adventure.platform.bukkit.BukkitAudiences;
 import org.bukkit.plugin.java.JavaPlugin;
 
+@SuppressWarnings("unused")
 public final class UserInterface {
     private static JavaPlugin plugin;
     private static BukkitAudiences bukkitAudiences;

--- a/src/main/java/me/xemor/userinterface/commands/BookInterfaceCmd.java
+++ b/src/main/java/me/xemor/userinterface/commands/BookInterfaceCmd.java
@@ -20,15 +20,24 @@ public class BookInterfaceCmd implements CommandExecutor {
             commandSender.sendMessage("Console cannot run this command!");
             return true;
         }
-        if (args.length != 2) {
+
+        if (args.length != 3) {
             commandSender.sendMessage("An error has occurred!");
             return true;
         }
-        String uuidInput = args[0];
-        String cmdIdentifier = args[1];
-        if (!uuidInput.equals(player.getUniqueId().toString())) return true;
+
+        String pluginName = args[0];
+        String uuidInput = args[1];
+        String cmdIdentifier = args[2];
+        if (UserInterface.getPlugin().getName().equalsIgnoreCase(pluginName) || !uuidInput.equals(player.getUniqueId().toString())) {
+            return true;
+        }
+
         BookInterface.Button thisButton = buttons.get(cmdIdentifier);
-        if (thisButton == null) return true;
+        if (thisButton == null) {
+            return true;
+        }
+
         thisButton.runnable().run();
         return true;
     }
@@ -36,30 +45,9 @@ public class BookInterfaceCmd implements CommandExecutor {
     public static void addButton(String identifier, BookInterface.Button button) {
         buttons.put(identifier, button);
         if (buttons.size() > 500) {
-            String warning =
-                """
-                        ERROR ///////////////////////////////////////////////////////////////////////////////////////////////
-                        ERROR //                                                                                           //
-                        ERROR //                                          ______                                           //
-                        ERROR //                                         //    \\\\                                          //
-                        ERROR //                                        //      \\\\                                         //
-                        ERROR //                                       //   ___  \\\\                                        //
-                        ERROR //                                      //   |   |  \\\\                                       //
-                        ERROR //                                     //    |   |   \\\\                                      //
-                        ERROR //                                    //     |   |    \\\\                                     //
-                        ERROR //                                   //      |   |     \\\\                                    //
-                        ERROR //                                  //       |___|      \\\\                                   //
-                        ERROR //                                 //         ___        \\\\                                  //
-                        ERROR //                                //         |   |        \\\\                                 //
-                        ERROR //                               //          |___|         \\\\                                //
-                        ERROR //                              //                          \\\\                               //
-                        ERROR //                             ////////////////////////////////                              //
-                        ERROR //                                                                                           //
-                        ERROR //       BUTTONS HAVE EXCEEDED 500, THIS IS LIKELY DUE TO MASS BookInterface CREATION        //
-                        ERROR //                                                                                           //
-                        ERROR ///////////////////////////////////////////////////////////////////////////////////////////////
-                    """;
-            UserInterface.getInstance().getLogger().severe(warning);
+            for (int i = 0; i < 10; i++) {
+                UserInterface.getPlugin().getLogger().severe("UserInterface Buttons have exceeded 500, this is likely due to mass BookInterface creation");
+            }
         }
     }
 


### PR DESCRIPTION
This might be more of a personal thing but I find it annoying have to update/have multiple jars per plugin so have changed this to allow the ability to shade it in instead.

Only caveat is that it requires you to relocate and run `UserInterface.enable()` on startup